### PR TITLE
Address config changes for 21.08+

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -192,6 +192,7 @@ slurm_JobAcctGatherType: "jobacct_gather/linux"
 slurm_JobAcctGatherFrequency: "energy=60,task=60"
 slurm_AcctGatherEnergyType: "acct_gather_energy/rapl"
 slurm_AcctGatherNodeFreq: "60"
+slurm_accounting_store_flags: "job_comment"
 
 # Job-private /tmp, /var/tmp and /dev/shm
 pam_use_namespace: False

--- a/templates/cgroup.conf.j2
+++ b/templates/cgroup.conf.j2
@@ -11,7 +11,9 @@ CgroupMountpoint={{ slurm_cgroup_mountpoint }}
 CgroupAutomount={{ slurm_cgroup_automount }}
 
 ConstrainCores={{ slurm_cgroup_constrain_cores }}
+{% if slurm_major_version|int < 21 %}
 TaskAffinity={{ slurm_cgroup_taskaffinity }}
+{% endif %}
 {% if slurm_cgroup_constrain_kmem_space is defined %}
 ConstrainKmemSpace={{ slurm_cgroup_constrain_kmem_space }}
 {% endif %}

--- a/templates/slurm.conf.j2
+++ b/templates/slurm.conf.j2
@@ -103,6 +103,8 @@ AccountingStorageType={{ slurm_accounting_storage_type }}
 AccountingStorageHost={{ slurm_accounting_storage_host }}
 {% if slurm_major_version|int < 21 %}
 AccountingStorageLoc={{ slurm_accounting_storage_loc }}
+{% else %}
+AccountingStoreFlags={{ slurm_accounting_store_flags }}
 {% endif %}
 AccountingStorageUser={{ slurm_accounting_storage_user }}
 AccountingStorageEnforce={{ slurm_accounting_storage_enforce }}


### PR DESCRIPTION
Tuning some default configs to work ok with 21.08. Restores older default behaviour to push comments to accounting db. Can be turned off with params.